### PR TITLE
Add currency stories to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,14 @@ Supported commands:
   pertaining to the **target**. If the **target** has a long history with the
   subreddit, only a summary of that history will be provided. The loansbot
   will include a link to where more information can be found on the **target**.
-- `$loan <MONEY>`: The LoansBot stores that the **comment** author
+- `$loan <MONEY> [AS CURRENCY]`: The LoansBot stores that the **comment** author
   has lent the **thread** author the **amount**. The **thread** author should
   respond with a confirmation they received the money, but this isn't strictly
   required. The ID of the newly created loan will be included in the
-  LoansBot's response.
+  LoansBot's response. The optional `AS <CURRENCY>` (where currency is a
+  3-letter ISO 4217 code) is used to indicate the primary currency for the
+  transaction is different than what the amount is given in.
+  For example `EUR 10 AS USD`. See Currencies for details.
 - `$paid <USER> <MONEY>`: The LoansBot stores that the **comment** author has
   been repaid **amount** by the **target**. If there are multiple loans out
   by the **target** to the **comment** author, the money will be applied to
@@ -86,3 +89,101 @@ Supported commands:
 - `PGPASSWORD`: Password to login with for the database
 - `SUBREDDITS`: The subreddits that the loansbot listens to, separated by
   commas
+
+## Repayments
+
+The LoansBot does not consider interest. A loan is considered repaid when the
+entire principal has been repaid, regardless of any outstanding interest. This
+is also reflected on the ban status of users (in most circumstances). So a
+$100 loan is considered fully repaid when the borrower has returned $100.
+Another way of looking at this is that interest amounts are not considered part
+of the info relevant to the LoansBot.
+
+## Currencies
+
+Loans can occur in any currency. The amount will be stored in the indicated
+currency, which is USD unless otherwise specified, but may be converted to
+other currencies as well for statistical purposes. The conversion rates are on
+a best-effort basis, which is typically the conversion rate around the time the
+command is processed (rather than when the command is made).
+
+To avoid confusion with exchange rates, it is best if the loan is tied to a
+particular currency for the purposes of repayment. For example, a loan of 10
+U.S. dollars will be considered repaid when 10 U.S. dollars have been repaid.
+Similarly, a 10 euro loan is repaid when 10 euro have been repaid.
+
+If a loan is repaid in a different currency than it was provided at, then
+exchange rates come into play. A loan has a primary currency, and the repayment
+will be converted into the primary currency at the exchange rate when the bot
+parses it. So if a $10 loan is given out, and 9 EUR are repaid, the repayment
+will be considered complete if at the time of parsing, 9 EUR is worth at least
+10 USD.
+
+If the lender and borrower agree that a loan is repaid even though the LoansBot
+does not, then the lender may make an additional repayment command for the
+missing amount to update the database (even if no actual money exchanges hands
+for the second repayment).
+
+Example flows:
+
+### Simple USD
+
+Sending and receiving payments in the same currency is recommended, and the
+most common choice is USD.
+
+- Joe lends Sally 10 USD with the command `$loan 10`. The amount is assumed to
+  be in USD since no currency was specified. The loan is assumed to be in the
+  same currency as the amount.
+- Sally repays Joe 10 USD, and Joe indicates this with `$paid /u/Sally 10`. The
+  amount is assumed to be in USD since no currency was specified. The amount is
+  in the same currency as the loan, so no conversion is required to know the
+  loan is repaid.
+
+### Simple EUR
+
+Sending and receiving in the same non-USD currency will also result in easy-to
+-understand behavior, and is fully supported.
+
+- Joe lends Sally 10 EUR with the command `$loan 10 EUR`. The amount is given
+  in euros explicitly. The loan is assumed to be in the same currency as the
+  amount (EUR).
+- Sally repays Joe 10 EUR, and Joe indicates this with `$paid /u/Sally 10 EUR`.
+  The amount is given in euros explicitly. The amount is in the same currency
+  as the loan, so no conversion is required to know the loan is repaid.
+
+### Loan sent in EUR but fixed to USD
+
+If it's known that the repayment will be in a different currency, the safest
+choice is for the lender and borrower to agree on an exchange rate in advance,
+then transfer the money in the repayment currency (to return to one of the
+above examples). Failing that, it's recommended that the loans principal be
+specified in the amount it will be returned in, so there is no accidental
+repayment under/overflow, as follows:
+
+- Joe lends Sally 10 EUR with the command `$loan 10 EUR AS USD`. The amount is
+  interpreted in euros as it was explicitly specified. The loan principal is
+  specified to be in USD. To make the example easier to follow, lets say the
+  bot converts the 10 EUR into 11 USD. The loan is stored in the database as
+  a principal of 11 USD.
+- Sally repays Joe 11 USD, and Joe indicates this with `$paid /u/Sally 11`. The
+  amount is assumed to be in USD since no currency was specified. The amount is
+  in the same currency as the loan, so no conversion is required to know the
+  loan is repaid.
+
+### Loan sent in USD but repaid in EUR
+
+Repayments which are in a different currency than the underlying loan can
+easily lead to loans which are not marked completely as paid (if the exchange
+rate is below what was expected) or have excess applied to other loans (if the
+exchange rate is above what was expected). Only advanced users should use this
+flow, and even then it is typically better to convert manually then make the
+command with the conversion already done
+
+- Joe lends Sally 11 USD with the command `$loan 11`. The amount is assumed to
+  be in USD since no currency was specified. The loan is assumed to be in the
+  same currency as the amount.
+- Sally repays Joe 10 EUR, and Joe indicates this with `$paid /u/Sally 10 EUR`.
+  The bot recognizes the loans principal is in dollars, so converts the 10 EUR
+  to dollars at the exchange rate when the bot parses. Let's say it converts to
+  $11.03. $11 go toward the loan principal and the $0.03 overflows, but there
+  are no other loans to apply the $0.03 to so it is ignored.


### PR DESCRIPTION
First-class currency support is going to be included in the rewrite,
as it's a challenging feature to add unless it's there from the
beginning. Furthermore, there are quite a lot of non-USD loans
on r/borrow and the current approach leads to a reasonable amount
of confusion for new lenders.