### PR TITLE
Clean shutdown force exit

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -160,6 +160,7 @@ def setup_clean_shutdown(logger, listeners):
         _log(Level.INFO, 'Clean shutdown finished normally')
         logger.close()
         logger.connection.close()
+        os._exit(0)
 
     signal.signal(signal.SIGINT, handle_shutdown)
     signal.signal(signal.SIGTERM, handle_shutdown)


### PR DESCRIPTION
Currently subprocesses still aren't dying when the main process is killed by supervisor. I can see them with `ps aux | grep python`. I can also see they *are* getting SIGTERM signals, and that there is a long delay before the main process dies that might be the 10s from the loop. I'm still confused why even though the subprocesses are marked as daemon they never get cleaned up, but this should do they job