### PR TITLE
Enable restarting, disconnect instead of idle connections

### DIFF
--- a/cfg/supervisor.conf
+++ b/cfg/supervisor.conf
@@ -170,6 +170,7 @@ serverurl=http://127.0.0.1:9001 ; use an http:// url to specify an inet socket
 
 [program:loansbot]
 command=%(ENV_PYTHON_COMMAND)s %(ENV_PYTHON_ARGS)s -m main
+autorestart=true
 environment=
     APPNAME="%(ENV_APPNAME)s",
     AMQP_HOST="%(ENV_AMQP_HOST)s",


### PR DESCRIPTION
This switches worker processes to using a disconnect and reconnect strategy for resources
rather than idling them for a long time. This wasn't applied to `main.py` but it probably should
be.

This is a temporary way of doing it; the lazy integrations from the web-backend work really
nicely and will greatly reduce clutter on this type of stuff