### PR TITLE
Utility runners

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -17,7 +17,8 @@ SUBPROCESSES = (
     'runners.comments', 'runners.modlog', 'runners.rechecks', 'runners.links',
     'runners.new_lender', 'runners.borrower_request', 'runners.default_permissions',
     'runners.trust_loan_delays', 'runners.deprecated_alerts', 'runners.loans_stats',
-    'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission'
+    'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',
+    'runners.lender_queue_trusts',
 )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,8 +13,9 @@ import atexit
 import signal
 
 
+# MISSING: runners.modlog
 SUBPROCESSES = (
-    'runners.comments', 'runners.modlog', 'runners.rechecks', 'runners.links',
+    'runners.comments', 'runners.rechecks', 'runners.links',
     'runners.new_lender', 'runners.borrower_request', 'runners.default_permissions',
     'runners.trust_loan_delays', 'runners.deprecated_alerts', 'runners.loans_stats',
     'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',

--- a/src/main.py
+++ b/src/main.py
@@ -13,14 +13,13 @@ import atexit
 import signal
 
 
-# MISSING: runners.modlog
 SUBPROCESSES = (
     'runners.comments', 'runners.rechecks', 'runners.links',
     'runners.new_lender', 'runners.borrower_request', 'runners.default_permissions',
     'runners.trust_loan_delays', 'runners.deprecated_alerts', 'runners.loans_stats',
     'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',
-    'runners.lender_queue_trusts', 'runners.modlog_cache_flush', 'runners.mod_changes',
-    'runners.mod_offboarding', 'runners.mod_onboarding_claim',
+    'runners.lender_queue_trusts', 'runners.modlog', 'runners.modlog_cache_flush',
+    'runners.mod_changes', 'runners.mod_offboarding', 'runners.mod_onboarding_claim',
     'runners.mod_onboarding', 'runners.mod_sync', 'runners.mod_onboarding_messages',
 )
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,9 @@ SUBPROCESSES = (
     'runners.new_lender', 'runners.borrower_request', 'runners.default_permissions',
     'runners.trust_loan_delays', 'runners.deprecated_alerts', 'runners.loans_stats',
     'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',
-    'runners.lender_queue_trusts', 'runners.modlog_cache_flush',
+    'runners.lender_queue_trusts', 'runners.modlog_cache_flush', 'runners.mod_changes',
+    'runners.mod_offboarding', 'runners.mod_onboarding_claim',
+    'runners.mod_onboarding', 'runners.mod_sync',
 )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -20,7 +20,7 @@ SUBPROCESSES = (
     'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',
     'runners.lender_queue_trusts', 'runners.modlog_cache_flush', 'runners.mod_changes',
     'runners.mod_offboarding', 'runners.mod_onboarding_claim',
-    'runners.mod_onboarding', 'runners.mod_sync',
+    'runners.mod_onboarding', 'runners.mod_sync', 'runners.mod_onboarding_messages',
 )
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,7 +18,7 @@ SUBPROCESSES = (
     'runners.new_lender', 'runners.borrower_request', 'runners.default_permissions',
     'runners.trust_loan_delays', 'runners.deprecated_alerts', 'runners.loans_stats',
     'runners.ban_unpaid', 'runners.lender_loan', 'runners.recheck_permission',
-    'runners.lender_queue_trusts',
+    'runners.lender_queue_trusts', 'runners.modlog_cache_flush',
 )
 
 

--- a/src/runners/borrower_request.py
+++ b/src/runners/borrower_request.py
@@ -54,8 +54,8 @@ def handle_loan_request(version, event):
             .get_sql(),
             (post['author'].lower(),)
         )
-        (author_user_id,) = itgs.read_cursor.fetchone()
-        if author_user_id is None:
+        row = itgs.read_cursor.fetchone()
+        if row is None:
             itgs.logger.print(
                 Level.TRACE,
                 'Ignoring loan request from /u/{} - they do not have any '
@@ -63,6 +63,7 @@ def handle_loan_request(version, event):
                 post['author']
             )
             return
+        (author_user_id,) = row
 
         loans = Table('loans')
         itgs.read_cursor.execute(

--- a/src/runners/default_permissions.py
+++ b/src/runners/default_permissions.py
@@ -3,9 +3,9 @@ the default permissions.
 """
 from lblogging import Level
 from lbshared.lazy_integrations import LazyIntegrations
-from lbshared.pypika_crits import exists
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 from .utils import listen_event
+import utils.perm_utils
 from functools import partial
 import time
 import os
@@ -37,9 +37,7 @@ def handle_user_signup(version, body):
     - `body (dict)`: The event body. Has the following keys:
       - `user_id (int)`: The id of the user who just signed up.
     """
-    with LazyIntegrations(
-            logger_iden='runners/default_permissions.py#handle_user_signup',
-            no_read_only=True) as itgs:
+    with LazyIntegrations(logger_iden=LOGGER_IDEN, no_read_only=True) as itgs:
         itgs.logger.print(
             Level.TRACE,
             'Detected user signup: id={}',
@@ -88,37 +86,44 @@ def handle_user_signup(version, body):
 
         (passwd_auth_id,) = row
 
+        if not DEFAULT_PERMISSIONS:
+            itgs.logger.print(
+                Level.DEBUG,
+                'No default permissions -> nothing to do for /u/{}',
+                username
+            )
+            return
+
         perms = Table('permissions')
-        passwd_auth_perms = Table('password_auth_permissions')
-        passwd_auth_perms_inner = passwd_auth_perms.as_('pap_inner')
-        itgs.write_cursor.execute(
-            Query.into(passwd_auth_perms)
-            .columns(
-                passwd_auth_perms.password_authentication_id,
-                passwd_auth_perms.permission_id
-            )
-            .from_(perms)
-            .select(
-                Parameter('%s'),
-                perms.id
-            )
-            .where(perms.name.isin([Parameter('%s') for _ in DEFAULT_PERMISSIONS]))
-            .where(
-                exists(
-                    Query.from_(passwd_auth_perms_inner)
-                    .where(passwd_auth_perms_inner.password_authentication_id == Parameter('%s'))
-                    .where(passwd_auth_perms_inner.permission_id == perms.id)
-                )
-                .negate()
-            )
+        itgs.read_cursor.execute(
+            Query.from_(perms)
+            .select(perms.id)
+            .where(perms.name.isin(*(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
             .get_sql(),
-            (
-                passwd_auth_id,
-                *DEFAULT_PERMISSIONS,
-                passwd_auth_id
-            )
+            DEFAULT_PERMISSIONS
         )
-        itgs.write_conn.commit()
+
+        perm_ids_to_grant = []
+        row = itgs.read_cursor.fetchone()
+        while row is not None:
+            perm_ids_to_grant.append(row[0])
+            row = itgs.read_cursor.fetchone()
+
+        if len(perm_ids_to_grant) != len(DEFAULT_PERMISSIONS):
+            itgs.logger.print(
+                Level.WARN,
+                'DEFAULT_PERMISSIONS has {} entries ({}), but it only maps '
+                'to {} actual permissions ({})!',
+                len(DEFAULT_PERMISSIONS), DEFAULT_PERMISSIONS,
+                len(perm_ids_to_grant), perm_ids_to_grant
+            )
+            if not perm_ids_to_grant:
+                return
+
+        utils.perm_utils.grant_permissions(
+            itgs, body['user_id'], 'Default permissions on signup', passwd_auth_id,
+            perm_ids_to_grant, commit=True
+        )
 
         itgs.logger.print(
             Level.INFO,

--- a/src/runners/default_permissions.py
+++ b/src/runners/default_permissions.py
@@ -98,7 +98,7 @@ def handle_user_signup(version, body):
         itgs.read_cursor.execute(
             Query.from_(perms)
             .select(perms.id)
-            .where(perms.name.isin(*(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
+            .where(perms.name.isin(tuple(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
             .get_sql(),
             DEFAULT_PERMISSIONS
         )

--- a/src/runners/lender_queue_trusts.py
+++ b/src/runners/lender_queue_trusts.py
@@ -1,0 +1,119 @@
+"""This runner is responsible for initializing a trust status of unknown and
+adding a user to the trust queue when they reach a threshold of loans completed
+as lender.
+"""
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lblogging import Level
+from .utils import listen_event
+import lbshared.delayed_queue as delayed_queue
+from lbshared.responses import get_letter_response
+import utils.reddit_proxy
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from pypika.functions import Count
+from pypika.terms import Star
+from functools import partial
+from datetime import datetime
+import time
+
+LOGGER_IDEN = 'runners/lender_queue_trusts.py'
+THRESHOLD_LOANS = 15
+
+
+def main():
+    version = time.time()
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event(itgs, 'loans.paid', partial(handle_loan_paid, version))
+
+
+def handle_loan_paid(version, event):
+    """Called shortly after a loan is paid.
+    """
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(
+            Level.TRACE,
+            'Detected /u/{} had a payment toward one of the loans he gave out...',
+            event['lender']['username']
+        )
+
+        trusts = Table('trusts')
+        itgs.read_cursor.execute(
+            Query.from_(trusts)
+            .select(1)
+            .where(trusts.user_id == Parameter('%s'))
+            .get_sql(),
+            (event['lender']['id'],)
+        )
+        if itgs.read_cursor.fetchone():
+            itgs.logger.print(
+                Level.TRACE,
+                '/u/{} already has a trust entry - nothing to do',
+                event['lender']['username']
+            )
+            return
+
+        loans = Table('loans')
+        itgs.read_cursor.execute(
+            Query.from_(loans)
+            .select(Count(Star()))
+            .where(loans.lender_id == Parameter('%s'))
+            .where(loans.repaid_at.notnull())
+            .where(loans.deleted_at.isnull())
+            .get_sql(),
+            (event['lender']['id'],)
+        )
+        (loans_compl_as_lender,) = itgs.read_cursor.fetchone()
+
+        if loans_compl_as_lender < THRESHOLD_LOANS:
+            itgs.logger.print(
+                Level.DEBUG,
+                '/u/{} now has {} loans completed as lender, which is below threshold of {}',
+                event['lender']['username'], loans_compl_as_lender, THRESHOLD_LOANS
+            )
+            return
+
+        itgs.logger.print(
+            Level.DEBUG,
+            '/u/{} reached threshold of {} loans completed as lender, '
+            'which is above the threshold of {}, queuing trust entry...',
+            event['lender']['username'], loans_compl_as_lender, THRESHOLD_LOANS
+        )
+        itgs.write_cursor.execute(
+            Query.into(trusts)
+            .columns(trusts.user_id, trusts.status, trusts.reason)
+            .insert(*(Parameter('%s') for _ in range(3)))
+            .get_sql(),
+            (event['lender']['id'], 'unknown', 'Vetting required')
+        )
+        delayed_queue.store_event(
+            itgs,
+            delayed_queue.QUEUE_TYPES['trust'],
+            datetime.now(),
+            {'username': event['lender']['username'].lower()},
+            commit=True
+        )
+        itgs.logger.print(
+            Level.INFO,
+            'Gave /u/{} an explicit unknown status and added to trust queue',
+            event['lender']['username']
+        )
+
+        (subject, body) = get_letter_response(
+            itgs, 'queue_trust_pm', username=event['lender']['username']
+        )
+
+        utils.reddit_proxy.send_request(
+            itgs, 'recheck_permission', version, 'compose',
+            {
+                'recipient': '/r/borrow',
+                'subject': subject,
+                'body': body
+            }
+        )
+
+        itgs.logger.print(
+            Level.TRACE,
+            'Successfully alerted modmail of the new entry in trust queue'
+        )

--- a/src/runners/mod_changes.py
+++ b/src/runners/mod_changes.py
@@ -1,0 +1,117 @@
+"""This runner is responsible for listening to modlog events about gaining and
+losing moderators and updating our set of moderators.
+"""
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lblogging import Level
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from .utils import listen_event
+import query_helper
+
+LOGGER_IDEN = 'runners/mod_changes.py'
+INTERESTING_ACTIONS = frozenset(('acceptmoderatorinvite', 'removemoderator'))
+
+
+def main():
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event(itgs, 'modlog.*', handle_action)
+
+
+def handle_action(act):
+    if act['action'] not in INTERESTING_ACTIONS:
+        return
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        if act['action'] == 'acceptmoderatorinvite':
+            new_mod_username = act['mod']
+            user_id = _find_or_create_user(itgs, new_mod_username)
+            if not _is_mod(itgs, user_id):
+                _add_mod(itgs, user_id, commit=True)
+                itgs.logger.print(
+                    Level.INFO,
+                    'Detected that /u/{} is now a moderator',
+                    new_mod_username
+                )
+                itgs.channel.basic_publish(
+                    'events',
+                    'mods.added',
+                    {'username': new_mod_username, 'user_id': user_id}
+                )
+        elif act['action'] == 'removemoderator':
+            lost_mod_username = act['target_author']
+            user_id = _find_or_create_user(itgs, new_mod_username)
+            if _is_mod(itgs, user_id):
+                _rem_mod(itgs, user_id, commit=True)
+                itgs.logger.info(
+                    Level.INFO,
+                    'Detected that /u/{} is no longer a moderator',
+                    lost_mod_username
+                )
+                itgs.channel.basic_publish(
+                    'events',
+                    'mods.removed',
+                    {'username': lost_mod_username, 'user_id': user_id}
+                )
+
+
+def _find_or_create_user(itgs: LazyItgs, unm: str) -> int:
+    users = Table('users')
+    (user_id,) = query_helper.find_or_create_or_find(
+        itgs,
+        (
+            Query.from_(users)
+            .select(users.id)
+            .where(users.username == Parameter('%s'))
+            .get_sql(),
+            (unm.lower(),)
+        ),
+        (
+            Query.into(users)
+            .columns(users.username)
+            .insert(Parameter('%s'))
+            .returning(users.id)
+            .get_sql(),
+            (unm.lower(),)
+        )
+    )
+    return user_id
+
+
+def _is_mod(itgs: LazyItgs, user_id: int) -> bool:
+    moderators = Table('moderators')
+    itgs.read_cursor.execute(
+        Query.from_(moderators)
+        .select(1)
+        .where(moderators.user_id == Parameter('%s'))
+        .get_sql(),
+        (user_id,)
+    )
+    return itgs.read_cursor.fetchone() is not None
+
+
+def _add_mod(itgs: LazyItgs, user_id: int, commit: bool = False):
+    moderators = Table('moderators')
+    itgs.write_cursor.execute(
+        Query.into(moderators)
+        .columns(moderators.user_id)
+        .insert(Parameter('%s'))
+        .get_sql(),
+        (user_id,)
+    )
+    if commit:
+        itgs.write_conn.commit()
+
+
+def _rem_mod(itgs: LazyItgs, user_id: int, commit: bool = False):
+    moderators = Table('moderators')
+    itgs.write_cursor.execute(
+        Query.from_(moderators)
+        .delete()
+        .where(moderators.user_id == Parameter('%s'))
+        .get_sql(),
+        (user_id,)
+    )
+    if commit:
+        itgs.write_conn.commit()

--- a/src/runners/mod_changes.py
+++ b/src/runners/mod_changes.py
@@ -6,6 +6,8 @@ from lblogging import Level
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 from .utils import listen_event
 import query_helper
+import json
+
 
 LOGGER_IDEN = 'runners/mod_changes.py'
 INTERESTING_ACTIONS = frozenset(('acceptmoderatorinvite', 'removemoderator'))
@@ -37,7 +39,7 @@ def handle_action(act):
                 itgs.channel.basic_publish(
                     'events',
                     'mods.added',
-                    {'username': new_mod_username, 'user_id': user_id}
+                    json.dumps({'username': new_mod_username, 'user_id': user_id})
                 )
         elif act['action'] == 'removemoderator':
             lost_mod_username = act['target_author']
@@ -52,7 +54,7 @@ def handle_action(act):
                 itgs.channel.basic_publish(
                     'events',
                     'mods.removed',
-                    {'username': lost_mod_username, 'user_id': user_id}
+                    json.dumps({'username': lost_mod_username, 'user_id': user_id})
                 )
 
 

--- a/src/runners/mod_changes.py
+++ b/src/runners/mod_changes.py
@@ -43,7 +43,7 @@ def handle_action(act):
                 )
         elif act['action'] == 'removemoderator':
             lost_mod_username = act['target_author']
-            user_id = _find_or_create_user(itgs, new_mod_username)
+            user_id = _find_or_create_user(itgs, lost_mod_username)
             if _is_mod(itgs, user_id):
                 _rem_mod(itgs, user_id, commit=True)
                 itgs.logger.info(

--- a/src/runners/mod_changes.py
+++ b/src/runners/mod_changes.py
@@ -46,7 +46,7 @@ def handle_action(act):
             user_id = _find_or_create_user(itgs, lost_mod_username)
             if _is_mod(itgs, user_id):
                 _rem_mod(itgs, user_id, commit=True)
-                itgs.logger.info(
+                itgs.logger.print(
                     Level.INFO,
                     'Detected that /u/{} is no longer a moderator',
                     lost_mod_username

--- a/src/runners/mod_offboarding.py
+++ b/src/runners/mod_offboarding.py
@@ -6,7 +6,7 @@ from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
 from lblogging import Level
 from lbshared.responses import get_letter_response
 import utils.reddit_proxy
-import utils.revoke_mod_permissions
+import utils.mod_onboarding_utils
 from .utils import listen_event
 from functools import partial
 import time

--- a/src/runners/mod_offboarding.py
+++ b/src/runners/mod_offboarding.py
@@ -1,0 +1,65 @@
+"""This runner is responsible for detecting when a moderator leaves the
+subreddit and stripping them of most of their permissions and sending
+them a farewell message thanking them for their contributions.
+"""
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lblogging import Level
+from lbshared.responses import get_letter_response
+import utils.reddit_proxy
+import utils.revoke_mod_permissions
+from .utils import listen_event
+from functools import partial
+import time
+
+LOGGER_IDEN = 'runners/mod_offboarding.py'
+"""The identifier for this runner in the logs"""
+
+FAREWELL_LETTER_NAME = 'mod_offboarding_farewell'
+"""The message we send to moderators we offboarded"""
+
+
+def main():
+    version = time.time()
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event(itgs, 'mods.removed', partial(handle_mod_removed, version))
+
+
+def handle_mod_removed(version, event):
+    with LazyItgs(logger_iden=LOGGER_IDEN, no_read_only=True) as itgs:
+        itgs.logger.print(
+            Level.DEBUG,
+            'Detected that /u/{} is no longer a moderator',
+            event['username']
+        )
+
+        utils.mod_onboarding_utils.revoke_mod_permissions(
+            itgs, event['user_id'], commit=True
+        )
+
+        itgs.logger.print(
+            Level.DEBUG,
+            'Revoked moderator privileges from /u/{}, sending a farewell...',
+            event['username']
+        )
+
+        (subject, body) = get_letter_response(
+            itgs, FAREWELL_LETTER_NAME, username=event['username']
+        )
+        utils.reddit_proxy.send_request(
+            itgs, 'mod_offboarding', version, 'compose',
+            {
+                'recipient': event['username'],
+                'subject': subject,
+                'body': body
+            }
+        )
+
+        itgs.logger.print(
+            Level.INFO,
+            'Revoked moderator privileges from /u/{} and sent a farewell message',
+            event['username']
+        )

--- a/src/runners/mod_onboarding.py
+++ b/src/runners/mod_onboarding.py
@@ -1,0 +1,108 @@
+"""This runner is responsible for listening for new moderators, granting them
+extensive permissions to the website, and then send them a greeting to let them
+know we've detected their account. If the moderator has not yet claimed their
+account this instead just sends them a message to claim their account, and the
+permissions will be granted in the runner runners/mod_onboarding_claim
+"""
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lblogging import Level
+from lbshared.responses import get_letter_response
+import utils.reddit_proxy
+import utils.mod_onboarding_utils
+from .utils import listen_event
+from functools import partial
+import time
+
+LOGGER_IDEN = 'runners/mod_onboarding'
+GREETING_LETTER_NAME = 'mod_onboarding_greeting'
+ACCOUNT_NOT_CLAIMED_LETTER_NAME = 'mod_onboarding_unclaimed'
+
+
+def main():
+    version = time.time()
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event(itgs, 'mods.added', partial(handle_mod_added, version))
+
+
+def handle_mod_added(version, event):
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(
+            Level.DEBUG,
+            'Detected that /u/{} is now a moderator',
+            event['username']
+        )
+
+        password_authentications = Table('password_authentications')
+        itgs.read_cursor.execute(
+            Query.from_(password_authentications)
+            .select(password_authentications.id)
+            .where(password_authentications.user_id == Parameter('%s'))
+            .where(password_authentications.human.eq(True))
+            .where(password_authentications.deleted.eq(False))
+            .get_sql(),
+            (event['user_id'],)
+        )
+        row = itgs.read_cursor.fetchone()
+        if row is None:
+            itgs.logger.print(
+                Level.DEBUG,
+                'Detected that /u/{} has not yet claimed his account',
+                event['username']
+            )
+            (subject, body) = get_letter_response(
+                itgs, ACCOUNT_NOT_CLAIMED_LETTER_NAME, username=event['username']
+            )
+            utils.reddit_proxy.send_request(
+                itgs, 'mod_onboarding', version, 'compose',
+                {
+                    'recipient': event['username'],
+                    'subject': subject,
+                    'body': body
+                }
+            )
+            utils.mod_onboarding_utils.store_letter_message(
+                itgs, event['user_id'], ACCOUNT_NOT_CLAIMED_LETTER_NAME, commit=True
+            )
+            itgs.logger.print(
+                Level.INFO,
+                'Sent a message to /u/{} to claim his account to gain mod '
+                'permissions on the website (since he is now a mod on the '
+                'subreddit)',
+                event['username']
+            )
+            return
+
+        (passwd_auth_id,) = row
+        utils.mod_onboarding_utils.grant_mod_permissions(
+            itgs, event['user_id'], passwd_auth_id, commit=True
+        )
+
+        itgs.logger.print(
+            Level.DEBUG,
+            'Granted all permissions to /u/{}, sending greeting...',
+            event['username']
+        )
+        (subject, body) = get_letter_response(
+            itgs, GREETING_LETTER_NAME, username=event['username']
+        )
+        utils.reddit_proxy.send_request(
+            itgs, 'mod_onboarding', version, 'compose',
+            {
+                'recipient': event['username'],
+                'subject': subject,
+                'body': body
+            }
+        )
+        utils.mod_onboarding_utils.store_letter_message(
+            itgs, event['user_id'], GREETING_LETTER_NAME, commit=True
+        )
+        itgs.logger.print(
+            Level.INFO,
+            'Granted all permissions to the new mod /u/{} & sent a greeting',
+            event['username']
+        )

--- a/src/runners/mod_onboarding_claim.py
+++ b/src/runners/mod_onboarding_claim.py
@@ -54,7 +54,7 @@ def handle_account_claimed(version, event):
         )
         (username,) = itgs.read_cursor.fetchone()
 
-        itgs.logger.rpint(
+        itgs.logger.print(
             Level.TRACE,
             'Detected that user {} is /u/{}',
             event['user_id'], username

--- a/src/runners/mod_onboarding_claim.py
+++ b/src/runners/mod_onboarding_claim.py
@@ -1,0 +1,128 @@
+"""This runner is responsible for listening to a moderator claiming their
+account. When it detects this it grants them extensive privileges and sends
+them a message to let them know.
+"""
+
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lblogging import Level
+from lbshared.responses import get_letter_response
+import utils.reddit_proxy
+import utils.mod_onboarding_utils
+from .utils import listen_event
+from functools import partial
+import time
+
+LOGGER_IDEN = 'runners/mod_onboarding_claim'
+GREETING_LETTER_NAME = 'mod_onboarding_claim_greeting'
+
+
+def main():
+    version = time.time()
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event(itgs, 'user.signup', partial(handle_account_claimed, version))
+
+
+def handle_account_claimed(version, event):
+    """Called when we detect that a user has just signed up. If they are a
+    moderator this will grant them all the appropriate permissions, otherwise
+    this does nothing.
+
+    Arguments:
+    - `version (float)`: Our version string when using the reddit proxy.
+    - `event (dict)`: The event body. Has the following keys:
+      - `user_id (int)`: The id of the user who just signed up.
+    """
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(
+            Level.TRACE,
+            'Detected that user {} just claimed their account',
+            event['user_id']
+        )
+
+        usrs = Table('users')
+        itgs.read_cursor.execute(
+            Query.from_(usrs)
+            .select(usrs.username)
+            .where(usrs.id == Parameter('%s'))
+            .get_sql(),
+            (event['user_id'],)
+        )
+        (username,) = itgs.read_cursor.fetchone()
+
+        itgs.logger.rpint(
+            Level.TRACE,
+            'Detected that user {} is /u/{}',
+            event['user_id'], username
+        )
+
+        moderators = Table('moderators')
+        itgs.read_cursor.execute(
+            Query.from_(moderators)
+            .select(1)
+            .where(moderators.user_id == Parameter('%s'))
+            .get_sql(),
+            (event['user_id'],)
+        )
+        if itgs.read_cursor.fetchone() is None:
+            itgs.logger.print(
+                Level.TRACE,
+                'Detected that /u/{} is not a moderator',
+                username
+            )
+            return
+
+        itgs.logger.print(
+            Level.DEBUG,
+            'Detected that the moderator /u/{} just claimed his account',
+            username
+        )
+
+        # We just sleep off the race condition with default_permissions to avoid
+        # having to deal with concurrent modification of password_authentications
+        time.sleep(3)
+
+        password_authentications = Table('password_authentications')
+        itgs.read_cursor.execute(
+            Query.from_(password_authentications)
+            .select(password_authentications.id)
+            .where(password_authentications.user_id == Parameter('%s'))
+            .where(password_authentications.human.eq(True))
+            .where(password_authentications.deleted.eq(False))
+            .get_sql(),
+            (event['user_id'],)
+        )
+        (passwd_auth_id,) = itgs.read_cursor.fetchone()
+
+        utils.mod_onboarding_utils.grant_mod_permissions(
+            itgs, event['user_id'], passwd_auth_id, commit=True
+        )
+
+        itgs.logger.print(
+            Level.DEBUG,
+            'Granted all permissions to /u/{}, sending greeting...',
+            username
+        )
+        (subject, body) = get_letter_response(
+            itgs, GREETING_LETTER_NAME, username=username
+        )
+        utils.reddit_proxy.send_request(
+            itgs, 'mod_onboarding_claim', version, 'compose',
+            {
+                'recipient': username,
+                'subject': subject,
+                'body': body
+            }
+        )
+        utils.mod_onboarding_utils.store_letter_message(
+            itgs, event['user_id'], GREETING_LETTER_NAME, commit=True
+        )
+        itgs.logger.print(
+            Level.INFO,
+            'Granted all permissions to the new mod /u/{} & sent a greeting',
+            username
+        )

--- a/src/runners/mod_onboarding_messages.py
+++ b/src/runners/mod_onboarding_messages.py
@@ -88,7 +88,7 @@ def send_messages(version):
                         mod_onboarding_messages.msg_order > Parameter('%s')
                     )
                 )
-                .orderby(mod_onboarding_messages.msg_order, Order.asc)
+                .orderby(mod_onboarding_messages.msg_order, order=Order.asc)
                 .limit(1)
                 .get_sql(),
                 (cur_msg_order, cur_msg_order,)

--- a/src/runners/mod_onboarding_messages.py
+++ b/src/runners/mod_onboarding_messages.py
@@ -63,6 +63,8 @@ def send_messages(version):
                     mod_onboarding_progress.msg_order < Parameter('%s')
                 )
             )
+            .get_sql(),
+            (max_msg_order,)
         )
         rows = itgs.read_cursor.fetchall()
 

--- a/src/runners/mod_onboarding_messages.py
+++ b/src/runners/mod_onboarding_messages.py
@@ -1,0 +1,139 @@
+"""Moderators are sent a series of messages from the LoansBot that introduces
+them to the tools available to them. We send each moderator one message per
+day until they have received every message.
+"""
+from lbshared.lazy_integrations import LazyIntegrations
+from lblogging import Level
+from lbshared.responses import get_response
+from .utils import sleep_until_hour_and_minute
+import utils.reddit_proxy
+import utils.mod_onboarding_utils
+from pypika import PostgreSQLQuery as Query, Table, Parameter, Order
+from pypika.functions import Max, CurTimestamp
+import time
+
+
+LOGGER_IDEN = 'runners/mod_onboarding_messages'
+
+
+def main():
+    version = time.time()
+    with LazyIntegrations(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    while True:
+        # 1PM UTC = 6AM PST = 9AM EST; at half to avoid conflict
+        # with deprecated_alerts
+        sleep_until_hour_and_minute(13, 30)
+        send_messages(version)
+
+
+def send_messages(version):
+    with LazyIntegrations(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.TRACE, 'Sending moderator onboarding messages...')
+
+        mod_onboarding_messages = Table('mod_onboarding_messages')
+        itgs.read_cursor.execute(
+            Query.from_(mod_onboarding_messages)
+            .select(Max(mod_onboarding_messages.msg_order))
+            .get_sql()
+        )
+        (max_msg_order,) = itgs.read_cursor.fetchone()
+        if max_msg_order is None:
+            itgs.logger.print(Level.DEBUG, 'There are no moderator onboarding messages.')
+            return
+
+        mod_onboarding_progress = Table('mod_onboarding_progress')
+        moderators = Table('moderators')
+        users = Table('users')
+        itgs.read_cursor.execute(
+            Query.from_(moderators)
+            .join(users)
+            .on(users.id == moderators.user_id)
+            .left_join(mod_onboarding_progress)
+            .on(mod_onboarding_progress.moderator_id == moderators.id)
+            .select(
+                users.id,
+                moderators.id,
+                users.username,
+                mod_onboarding_progress.msg_order
+            )
+            .where(
+                mod_onboarding_progress.msg_order.isnull() | (
+                    mod_onboarding_progress.msg_order < Parameter('%s')
+                )
+            )
+        )
+        rows = itgs.read_cursor.fetchall()
+
+        responses = Table('responses')
+        titles = responses.as_('titles')
+        bodies = responses.as_('bodies')
+        for (user_id, mod_id, username, cur_msg_order) in rows:
+            itgs.read_cursor.execute(
+                Query.from_(mod_onboarding_messages)
+                .join(titles).on(titles.id == mod_onboarding_messages.title_id)
+                .join(bodies).on(bodies.id == mod_onboarding_messages.body_id)
+                .select(
+                    mod_onboarding_messages.msg_order,
+                    titles.id,
+                    titles.name,
+                    bodies.id,
+                    bodies.name
+                )
+                .where(
+                    Parameter('%s').isnull() | (
+                        mod_onboarding_messages.msg_order > Parameter('%s')
+                    )
+                )
+                .orderby(mod_onboarding_messages.msg_order, Order.asc)
+                .limit(1)
+                .get_sql(),
+                (cur_msg_order, cur_msg_order,)
+            )
+            (
+                new_msg_order,
+                title_id,
+                title_name,
+                body_id,
+                body_name
+            ) = itgs.read_cursor.fetchone()
+            title_formatted = get_response(itgs, title_name, username=username)
+            body_formatted = get_response(itgs, body_name, username=username)
+            utils.reddit_proxy.send_request(
+                itgs, 'mod_onboarding_messages', version, 'compose',
+                {
+                    'recipient': username,
+                    'subject': title_formatted,
+                    'body': body_formatted
+                }
+            )
+            utils.mod_onboarding_utils.store_letter_message_with_id_and_names(
+                itgs, user_id, title_id, title_name, body_id, body_name
+            )
+            if cur_msg_order is None:
+                itgs.write_cursor.execute(
+                    Query.into(mod_onboarding_progress)
+                    .columns(
+                        mod_onboarding_progress.moderator_id,
+                        mod_onboarding_progress.msg_order
+                    )
+                    .insert(*(Parameter('%s') for _ in range(2)))
+                    .get_sql(),
+                    (mod_id, new_msg_order)
+                )
+            else:
+                itgs.write_cursor.execute(
+                    Query.update(mod_onboarding_progress)
+                    .set(mod_onboarding_progress.msg_order, Parameter('%s'))
+                    .set(mod_onboarding_progress.updated_at, CurTimestamp())
+                    .where(mod_onboarding_progress.moderator_id == Parameter('%s'))
+                    .get_sql(),
+                    (new_msg_order, mod_id)
+                )
+            itgs.write_conn.commit()
+            itgs.logger.print(
+                Level.INFO,
+                'Successfully sent moderator onboarding message (msg_order={}) to /u/{}',
+                new_msg_order, username
+            )

--- a/src/runners/mod_sync.py
+++ b/src/runners/mod_sync.py
@@ -9,6 +9,7 @@ import utils.reddit_proxy
 import typing
 import time
 import os
+import json
 
 LOGGER_IDEN = 'runners/mod_sync.py'
 LAST_CHECK_AT_KEY = 'runners/mod_sync/last_check_at'
@@ -103,7 +104,7 @@ def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
         itgs.channel.basic_publish(
             'events',
             'mods.removed',
-            {'username': removed_mod, 'user_id': removed_user_id}
+            json.dumps({'username': removed_mod, 'user_id': removed_user_id})
         )
 
     for added_mod in new_moderators:
@@ -127,7 +128,7 @@ def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
         itgs.channel.basic_publish(
             'events',
             'mods.added',
-            {'username': added_mod, 'user_id': added_user_id}
+            json.dumps({'username': added_mod, 'user_id': added_user_id})
         )
 
 

--- a/src/runners/mod_sync.py
+++ b/src/runners/mod_sync.py
@@ -31,7 +31,7 @@ def main():
 
         with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
             sync_moderators_with_poll_and_diff(version, itgs)
-            _set_last_check_at(the_time)
+            _set_last_check_at(itgs, the_time)
             last_check_at = the_time
 
 

--- a/src/runners/mod_sync.py
+++ b/src/runners/mod_sync.py
@@ -6,7 +6,7 @@ from lblogging import Level
 from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
 from pypika import PostgreSQLQuery as Query, Table, Parameter
 import utils.reddit_proxy
-import query_helper
+import utils.account_utils
 import typing
 import time
 import os
@@ -114,7 +114,7 @@ def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
             'Detected that /u/{} is now a moderator',
             added_mod
         )
-        added_user_id = _find_or_create_user(itgs, added_mod)
+        added_user_id = utils.account_utils.find_or_create_user(itgs, added_mod)
         itgs.write_cursor.execute(
             Query.into(moderators)
             .columns(moderators.user_id)
@@ -140,26 +140,3 @@ def _get_last_check_at(itgs: LazyItgs) -> typing.Optional[float]:
 
 def _set_last_check_at(itgs: LazyItgs, new_last_check_at: float) -> None:
     itgs.cache.set(LAST_CHECK_AT_KEY, str(new_last_check_at))
-
-
-def _find_or_create_user(itgs: LazyItgs, unm: str) -> int:
-    users = Table('users')
-    (user_id,) = query_helper.find_or_create_or_find(
-        itgs,
-        (
-            Query.from_(users)
-            .select(users.id)
-            .where(users.username == Parameter('%s'))
-            .get_sql(),
-            (unm.lower(),)
-        ),
-        (
-            Query.into(users)
-            .columns(users.username)
-            .insert(Parameter('%s'))
-            .returning(users.id)
-            .get_sql(),
-            (unm.lower(),)
-        )
-    )
-    return user_id

--- a/src/runners/mod_sync.py
+++ b/src/runners/mod_sync.py
@@ -1,0 +1,146 @@
+"""This runner is responsible for occassionally fetching the current list of
+moderators on the primary subreddits and diffing them with our internal list
+of moderators then updating our list as necessary.
+"""
+from lblogging import Level
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+import utils.reddit_proxy
+import typing
+import time
+import os
+
+LOGGER_IDEN = 'runners/mod_sync.py'
+LAST_CHECK_AT_KEY = 'runners/mod_sync/last_check_at'
+TIME_BETWEEN_CHECKS_SECONDS = 60 * 60 * 24 * 7
+
+
+def main():
+    version = time.time()
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+        last_check_at = _get_last_check_at(itgs)
+
+    while True:
+        the_time = time.time()
+        if last_check_at is not None and (the_time - last_check_at) < TIME_BETWEEN_CHECKS_SECONDS:
+            time.sleep(TIME_BETWEEN_CHECKS_SECONDS - the_time + last_check_at)
+            continue
+
+        with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+            sync_moderators_with_poll_and_diff(version, itgs)
+            _set_last_check_at(the_time)
+            last_check_at = the_time
+
+
+def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
+    """Fetch the list of moderators from reddit, then diff them with who we
+    know about, and then use that diff to update our list."""
+    subreddits = os.environ['SUBREDDITS'].split(',')
+
+    mods = set()
+    for sub in subreddits:
+        body = utils.reddit_proxy.send_request(
+            itgs, 'mod_sync', version, 'subreddit_moderators', {
+                'subreddit': sub
+            }
+        )
+
+        if body['type'] != 'copy':
+            itgs.logger.print(
+                Level.INFO,
+                'Got unexpected response type {} for subreddit moderators to {}'
+                '- not syncing moderators',
+                body['type'], sub
+            )
+            return
+
+        for mod in body['info']['mods']:
+            mods.add(mod['username'].lower())
+
+    moderators = Table('moderators')
+    users = Table('users')
+    itgs.read_cursor.execute(
+        Query.from_(moderators)
+        .join(users).on(users.id == moderators.user_id)
+        .select(users.username)
+        .where(users.username.notin([Parameter('%s') for _ in mods]))
+        .get_sql(),
+        list(mods)
+    )
+
+    removed_mods = [[r[0] for r in itgs.read_cursor.fetchall()]]
+
+    new_moderators = set(mods)
+    itgs.read_cursor.execute(
+        Query.from_(moderators)
+        .join(users).on(users.id == moderators.user_id)
+        .select(users.username)
+        .where(users.username.isin([Parameter('%s') for _ in mods]))
+        .get_sql(),
+        list(mods)
+    )
+    row = itgs.read_cursor.fetchone()
+    while row is not None:
+        new_moderators.remove(row[0])
+        row = itgs.read_cursor.fetchone()
+
+    for removed_mod in removed_mods:
+        itgs.logger.print(
+            Level.INFO,
+            'Detected that /u/{} is no longer a moderator',
+            removed_mod
+        )
+        itgs.write_cursor.execute(
+            Query.from_(moderators)
+            .join(users).on(users.id == moderators.user_id)
+            .where(users.username == Parameter('%s'))
+            .delete()
+            .returning(users.id)
+            .get_sql(),
+            (removed_mod,)
+        )
+        (removed_user_id,) = itgs.write_cursor.fetchone()
+        itgs.write_conn.commit()
+        itgs.channel.basic_publish(
+            'events',
+            'mods.removed',
+            {'username': removed_mod, 'user_id': removed_user_id}
+        )
+
+    for added_mod in new_moderators:
+        itgs.logger.print(
+            Level.INFO,
+            'Detected that /u/{} is now a moderator',
+            added_mod
+        )
+        itgs.write_cursor.execute(
+            Query.into(moderators)
+            .columns(moderators.user_id)
+            .from_(users)
+            .select(users.id)
+            .where(users.username == Parameter('%s'))
+            .returning(moderators.user_id)
+            .get_sql(),
+            (added_mod,)
+        )
+        (added_user_id,) = itgs.write_cursor.fetchone()
+        itgs.write_conn.commit()
+        itgs.channel.basic_publish(
+            'events',
+            'mods.added',
+            {'username': added_mod, 'user_id': added_user_id}
+        )
+
+
+def _get_last_check_at(itgs: LazyItgs) -> typing.Optional[float]:
+    last_check_at_bytes: bytes = itgs.cache.get(LAST_CHECK_AT_KEY)
+    if last_check_at_bytes is None:
+        return None
+
+    return float(last_check_at_bytes)
+
+
+def _set_last_check_at(itgs: LazyItgs, new_last_check_at: float) -> None:
+    itgs.cache.set(LAST_CHECK_AT_KEY, str(new_last_check_at))

--- a/src/runners/mod_sync.py
+++ b/src/runners/mod_sync.py
@@ -70,7 +70,7 @@ def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
         list(mods)
     )
 
-    removed_mods = [[r[0] for r in itgs.read_cursor.fetchall()]]
+    removed_mods = [r[0] for r in itgs.read_cursor.fetchall()]
 
     new_moderators = set(mods)
     itgs.read_cursor.execute(
@@ -93,12 +93,9 @@ def sync_moderators_with_poll_and_diff(version: float, itgs: LazyItgs) -> None:
             removed_mod
         )
         itgs.write_cursor.execute(
-            Query.from_(moderators)
-            .join(users).on(users.id == moderators.user_id)
-            .where(users.username == Parameter('%s'))
-            .delete()
-            .returning(users.id)
-            .get_sql(),
+            'DELETE FROM moderators '
+            'USING users '
+            'WHERE users.id = moderators.user_id AND users.username=%s RETURNING users.id',
             (removed_mod,)
         )
         (removed_user_id,) = itgs.write_cursor.fetchone()

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -25,6 +25,9 @@ def main():
     """Periodically scans the moderator log of /r/borrow to check if any users
     need their permissions cache flushed. This avoids permission checking
     scaling extremely poorly as there are more unique users"""
+    # Sleep a few seconds to ensure other runners are up and listening
+    time.sleep(5)
+
     version = time.time()
     with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
         itgs.logger.print(Level.DEBUG, 'Successfully booted up, version = {}', version)

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -59,7 +59,7 @@ def scan_for_modactions(itgs: LazyItgs, version: float):
             finished = True
 
         for act in actions:
-            if last_seen is None or act['created_utc'] > last_seen:
+            if new_last_seen is None or act['created_utc'] > new_last_seen:
                 handle_action(itgs, act)
                 new_last_seen = act['created_utc']
             else:

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -51,12 +51,20 @@ def scan_for_modactions(itgs: LazyItgs, version: float):
     if last_seen is not None:
         last_seen = float(last_seen)
 
+    # Seen afters is just paranoia in case reddit gets stuck in a loop.
+    seen_afters = set()
+
     new_last_seen = last_seen
     finished = False
     while not finished:
         actions, after = _fetch_actions(itgs, version, after)
+        if after is not None and after in seen_afters:
+            break
+
         if after is None:
             finished = True
+        else:
+            seen_afters.add(after)
 
         for act in actions:
             if last_seen is None or act['created_utc'] > last_seen:

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -14,11 +14,11 @@ import json
 
 LOGGER_IDEN = 'runners/modlog.py'
 MOST_RECENT_ACTION_SEEN_KEY = 'loansbot_runners_modlog_last_action_at'
-PRODUCER_ACTIONS = frozenset(
+PRODUCER_ACTIONS = frozenset((
     'banuser', 'unbanuser',
     'acceptmoderatorinvite', 'removemoderator',
     'addcontributor', 'removecontributor'
-)
+))
 
 
 def main():

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -59,7 +59,7 @@ def scan_for_modactions(itgs: LazyItgs, version: float):
             finished = True
 
         for act in actions:
-            if new_last_seen is None or act['created_utc'] > new_last_seen:
+            if last_seen is None or act['created_utc'] > last_seen:
                 handle_action(itgs, act)
                 new_last_seen = act['created_utc']
             else:

--- a/src/runners/modlog.py
+++ b/src/runners/modlog.py
@@ -64,7 +64,6 @@ def scan_for_modactions(itgs: LazyItgs, version: float):
                 new_last_seen = act['created_utc']
             else:
                 finished = True
-                break
 
     if new_last_seen is not None:
         itgs.cache.set(MOST_RECENT_ACTION_SEEN_KEY, str(new_last_seen))

--- a/src/runners/modlog_cache_flush.py
+++ b/src/runners/modlog_cache_flush.py
@@ -25,7 +25,7 @@ def main():
         itgs.logger.print(Level.DEBUG, 'Successfully booted up')
 
     with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
-        listen_event_with_itgs(itgs, 'modlog.*', handle_action, keep_alive=10)
+        listen_event_with_itgs(itgs, 'modlog.*', handle_action, keepalive=10)
 
 
 def handle_action(itgs, act):

--- a/src/runners/modlog_cache_flush.py
+++ b/src/runners/modlog_cache_flush.py
@@ -1,0 +1,54 @@
+"""This is the entry point of a process which listens to the borrow moderator
+queue to speed up propagation of privilege events to our caches.
+
+If a user is promoted to moderator, demoted from moderator, approved,
+unapproved, banned, or unbanned we flush their permissions cache.
+"""
+from lblogging import Level
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from .utils import listen_event_with_itgs
+import perms.manager
+
+LOGGER_IDEN = 'runners/modlog_cache_flush.py'
+PERMS_RELATED_ACTIONS = {
+    'banuser': ('target_author',),
+    'unbanuser': ('target_author',),
+    'acceptmoderatorinvite': ('mod',),
+    'removemoderator': ('target_author',),
+    'addcontributor': ('target_author',),
+    'removecontributor': ('target_author',)
+}
+
+
+def main():
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        itgs.logger.print(Level.DEBUG, 'Successfully booted up')
+
+    with LazyItgs(logger_iden=LOGGER_IDEN) as itgs:
+        listen_event_with_itgs(itgs, 'modlog.*', handle_action, keep_alive=10)
+
+
+def handle_action(itgs, act):
+    if act['action'] not in PERMS_RELATED_ACTIONS:
+        return
+
+    keys = PERMS_RELATED_ACTIONS[act['action']]
+    for key in keys:
+        username = act.get(key)
+        if username is None:
+            itgs.logger.print(
+                Level.DEBUG,
+                'Found modlog action {} by /u/{} - which we expected to '
+                + 'have a key {} which would be the username for someone who '
+                + 'should have their permissions rechecked, but it did not have one',
+                act['action'], act['mod'], key
+            )
+        else:
+            itgs.logger.print(
+                Level.INFO,
+                '/u/{} performed action {} toward /u/{}, so /u/{} will have '
+                + 'their permissions rechecked on their next interaction, rather '
+                + 'than relying on cached values.',
+                act['mod'], act['action'], username, username
+            )
+            perms.manager.flush_cache(itgs, username)

--- a/src/runners/utils.py
+++ b/src/runners/utils.py
@@ -2,6 +2,7 @@
 from datetime import datetime, timedelta
 import time
 import json
+from lbshared.lazy_integrations import LazyIntegrations
 from lblogging import Level
 
 
@@ -36,10 +37,8 @@ def listen_event(itgs, event_name, handler):
     queue_declare_result = consumer_channel.queue_declare('', exclusive=True)
     queue_name = queue_declare_result.method.queue
     consumer_channel.queue_bind(queue_name, 'events', event_name)
-    consumer = consumer_channel.consume(queue_name, inactivity_timeout=600)
+    consumer = consumer_channel.consume(queue_name, inactivity_timeout=None)
     for method_frame, props, body_bytes in consumer:
-        if method_frame is None:
-            continue
         body_str = body_bytes.decode('utf-8')
         body = json.loads(body_str)
 
@@ -51,4 +50,91 @@ def listen_event(itgs, event_name, handler):
             break
 
         consumer_channel.basic_ack(method_frame.delivery_tag)
-    consumer.cancel()
+    consumer_channel.cancel()
+
+
+def listen_event_with_itgs(itgs, event_name, handler, keepalive=10):
+    """Listen to events on the `"events"` topic exchange which match the given
+    event name. When they come in, sends them to the `handler` function. Hence
+    this operates very similarly to `listen_event`, except this also forwards
+    a `LazyIntegrations` object to `handler`.
+
+    It does _not_ forward the itgs object that it receives as an argument.
+    Rather, it starts up a new `LazyIntegrations` if it does not have one open
+    when receiving an event and forwards that integrations object to
+    `handler`. This avoids keeping a database connection open while we are
+    listening for events but not getting any, which would be wasteful.
+
+    The integrations object that we open is reused until `keepalive` seconds pass
+    without an event, and then we close it. This means that `handler` should be
+    careful not to depend on implicit rollbacks; it should explicitly rollback.
+
+    Arguments:
+    - `itgs (LazyIntegrations)`: The lazy integrations to use for listening to
+      the topic exchange. This should be fairly fresh as this function will not
+      return naturally and hence any connections open in this `itgs` will stay
+      alive even if they are not needed. Typically this is newly created.
+      New `LazyIntegration` objects created by this function will copy `itgs`
+      `logger_iden`.
+    - `event_name (str)`: The name or pattern for events that should be listened
+      for. May use a star (*) to substitute for exactly one word and a hash (#)
+      to substitute for zero or more words.
+    - `handler (callable)`: A function which we call with `(handler_itgs, event)`
+      whenever we receive a matching event name. `handler_itgs` is an instance of
+      `LazyIntegrations` and `event` is the payload of the event interpreted as
+      utf-8 text and parsed as json.
+    - `keepalive (int, float)`: If we do not receive an event for `keepalive`
+      seconds after a previous event we will close the `LazyIntegrations` object
+      we use for `handler` and will reopen it for the next event.
+
+    Returns:
+    - This function never returns unless an exception occurs, in which case the
+      exception is logged and this function returns.
+    """
+    itgs.channel.exchange_declare(
+        'events',
+        'topic'
+    )
+
+    consumer_channel = itgs.amqp.channel()
+    queue_declare_result = consumer_channel.queue_declare('', exclusive=True)
+    queue_name = queue_declare_result.method.queue
+    consumer_channel.queue_bind(queue_name, 'events', event_name)
+
+    while True:
+        consumer = consumer_channel.consume(queue_name, inactivity_timeout=None)
+        handler_itgs = None
+        for method_frame, props, body_bytes in consumer:
+            break
+
+        with LazyIntegrations(logger_iden=itgs.logger_iden) as handler_itgs:
+            def handle_event():
+                body_str = body_bytes.decode('utf-8')
+                body = json.loads(body_str)
+
+                try:
+                    handler(handler_itgs, body)
+                except:  # noqa
+                    handler_itgs.logger.exception(Level.ERROR)
+                    consumer_channel.basic_nack(method_frame.delivery_tag, requeue=False)
+                    return False
+
+                consumer_channel.basic_ack(method_frame.delivery_tag)
+                return True
+
+            cont = handle_event()
+            consumer_channel.cancel()
+            if not cont:
+                break
+
+            consumer = consumer_channel.consume(queue_name, inactivity_timeout=keepalive)
+            for method_frame, props, body_bytes in consumer:
+                if method_frame is None:
+                    break
+                cont = handle_event()
+                if not cont:
+                    break
+
+            consumer_channel.cancel()
+            if not cont:
+                break

--- a/src/utils/account_utils.py
+++ b/src/utils/account_utils.py
@@ -1,0 +1,28 @@
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+import query_helper
+
+
+def find_or_create_user(itgs: LazyItgs, unm: str) -> int:
+    """Find or create a user with the given username.
+    """
+    users = Table('users')
+    (user_id,) = query_helper.find_or_create_or_find(
+        itgs,
+        (
+            Query.from_(users)
+            .select(users.id)
+            .where(users.username == Parameter('%s'))
+            .get_sql(),
+            (unm.lower(),)
+        ),
+        (
+            Query.into(users)
+            .columns(users.username)
+            .insert(Parameter('%s'))
+            .returning(users.id)
+            .get_sql(),
+            (unm.lower(),)
+        )
+    )
+    return user_id

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -1,0 +1,175 @@
+"""These utility functions are related to moderator onboarding, which is split
+across several runners.
+"""
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from pypika.terms import Not
+from lbshared.pypika_crits import ExistsCriterion
+from .perm_utils import grant_permissions, revoke_permissions
+import typing
+import os
+
+if typing.TYPE_CHECKING:
+    from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+
+
+DEFAULT_PERMISSIONS = tuple(os.getenv('DEFAULT_PERMISSIONS', '').split(','))
+"""The list of permissions we grant to new users when they sign up"""
+
+
+def store_letter_message(itgs: LazyItgs, user_id: int, letter_name: str, commit=False):
+    """This function is responsible for storing that we sent an onboarding
+    letter message to the given user, where the subject and body were
+    fetched as if by `lbshared.responses.get_letter_response`
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to use to connect to networked
+      components.
+    - `user_id (int)`: The id of the user who we sent the message to
+    - `letter_name (str)`: The base part of the response for both the title and
+      subject. The title response name is formed by appending `_title` and the
+      subject is formed by appending `_body`
+    - `commit (bool)`: True to commit the change immediately, false not to
+    """
+    (body_name, title_name) = (f'{letter_name}_body', f'{letter_name}_title')
+
+    responses = Table('responses')
+    itgs.read_cursor.execute(
+        Query.from_(responses)
+        .select(responses.id, responses.name)
+        .where(responses.name.isin((Parameter('%s'), Parameter('%s'))))
+        .get_sql(),
+        (body_name, title_name)
+    )
+    rows = itgs.read_cursor.fetchall()
+    if len(rows) != 2:
+        raise Exception(f'expected 2 rows for letter base {letter_name}, got {len(rows)}')
+
+    (body_id, title_id) = [r[0] for r in sorted(rows, key=lambda x: x[1])]
+
+    mod_onboarding_msg_history = Table('mod_onboarding_msg_history')
+    itgs.write_cursor.execute(
+        Query.into(mod_onboarding_msg_history)
+        .columns(
+            mod_onboarding_msg_history.user_id,
+            mod_onboarding_msg_history.title_response_id,
+            mod_onboarding_msg_history.title_response_name,
+            mod_onboarding_msg_history.body_response_id,
+            mod_onboarding_msg_history.body_response_name
+        )
+        .insert(*(Parameter('%s') for _ in range(5)))
+        .get_sql(),
+        (user_id, title_id, title_name, body_id, body_name)
+    )
+    if commit:
+        itgs.write_conn.commit()
+
+
+def grant_mod_permissions(itgs: LazyItgs, user_id: int, passwd_auth_id: int, commit=False):
+    """This function grants the given user all the permissions that moderators
+    should have on the given password authentication id. This will handle
+    updating the audit tables.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The lazy integrations to use
+    - `user_id (int)`: The id of the user we are granting mod permissions on
+    - `passwd_auth_id (int)`: The id of the password authentication we are
+      granting permissions.
+    - `commit (bool)`: True to commit the transaction, false not to.
+    """
+    permissions = Table('permissions')
+    passwd_auth_perms = Table('password_auth_permissions')
+    itgs.read_cursor.execute(
+        Query.from_(permissions)
+        .select(permissions.id)
+        .where(
+            Not(
+                ExistsCriterion(
+                    Query.from_(passwd_auth_perms)
+                    .where(passwd_auth_perms.password_authentication_id == Parameter('%s'))
+                    .where(passwd_auth_perms.permission_id == permissions.id)
+                    .get_sql()
+                )
+            )
+        )
+    )
+    perm_ids_to_grant = []
+    row = itgs.read_cursor.fetchone()
+    while row is not None:
+        (row_id,) = row
+        perm_ids_to_grant.append(row_id)
+        row = itgs.read_cursor.fetchone()
+
+    if not perm_ids_to_grant:
+        return
+
+    grant_permissions(
+        itgs,
+        user_id,
+        'Became moderator',
+        passwd_auth_id,
+        perm_ids_to_grant,
+        commit=commit
+    )
+
+
+def revoke_mod_permissions(itgs: LazyItgs, user_id: int, commit=False):
+    """This function revokes all non-default permissions on the given user
+    because they are no longer a moderator. This will apply to all
+    authentication methods and will log them out. This will handle updating the
+    audit tables.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to use for networked services
+    - `user_id (int)`: The id of the user who is no longer a moderator
+    - `commit (bool)`: True to commit the transaction, false not to
+    """
+    permissions = Table('permissions')
+    passwd_auths = Table('password_authentications')
+    passwd_auth_perms = Table('password_auth_permissions')
+
+    itgs.read_cursor.execute(
+        Query.from_(passwd_auths)
+        .select(passwd_auths.id)
+        .where(passwd_auths.user_id == Parameter('%s'))
+        .where(passwd_auths.deleted.eq(False))
+        .get_sql(),
+        (user_id,)
+    )
+
+    passwd_auth_ids = []
+    row = itgs.read_cursor.fetchone()
+    while row is not None:
+        passwd_auth_ids.append(row[0])
+        row = itgs.read_cursor.fetchone()
+
+    for passwd_auth_id in passwd_auth_ids:
+        query = (
+            Query.from_(passwd_auth_perms)
+            .select(passwd_auth_perms.permission_id)
+            .where(passwd_auth_perms.password_authentication_id == Parameter('%s'))
+        )
+        if DEFAULT_PERMISSIONS:
+            query = (
+                query
+                .join(permissions).on(permissions.id == passwd_auth_perms.permission_id)
+                .where(permissions.name.notin(*(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
+            )
+
+        itgs.read_cursor.execute(
+            query.get_sql(),
+            (passwd_auth_id, *DEFAULT_PERMISSIONS)
+        )
+        perm_ids_to_revoke = []
+        row = itgs.read_cursor.fetchone()
+        while row is not None:
+            perm_ids_to_revoke.append(row[0])
+            row = itgs.read_cursor.fetchone()
+
+        if perm_ids_to_revoke:
+            revoke_permissions(
+                itgs, user_id, 'No longer a mod',
+                passwd_auth_id, perm_ids_to_revoke
+            )
+
+    if commit:
+        itgs.write_conn.commit()

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -45,7 +45,34 @@ def store_letter_message(itgs: 'LazyItgs', user_id: int, letter_name: str, commi
         raise Exception(f'expected 2 rows for letter base {letter_name}, got {len(rows)}')
 
     (body_id, title_id) = [r[0] for r in sorted(rows, key=lambda x: x[1])]
+    store_letter_message_with_id_and_names(
+        itgs, user_id, title_id, title_name,
+        body_id, body_name, commit=commit
+    )
 
+
+def store_letter_message_with_id_and_names(
+        itgs: 'LazyItgs', user_id: int,
+        title_id: int, title_name: str,
+        body_id: int, body_name: str,
+        commit=False):
+    """Similar to store_letter_message except this assumes you already know the
+    response information that was sent, ie., the id of the row in responses and
+    the name of the response.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to use to connect to networked
+      components
+    - `user_id (int)`: The id of the user who we sent the message to
+    - `title_id (int)`: The ID of the title
+    - `title_name (str)`: The current name of the title, in case the title
+      response gets deleted.
+    - `body_id (int)`: The ID of the body
+    - `body_name (str)`: The current name of the body, in case the body
+      response gets deleted.
+    - `commit (bool)`: True to immediately commit the transaction, false not
+      to.
+    """
     mod_onboarding_msg_history = Table('mod_onboarding_msg_history')
     itgs.write_cursor.execute(
         Query.into(mod_onboarding_msg_history)

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -153,7 +153,7 @@ def revoke_mod_permissions(itgs: 'LazyItgs', user_id: int, commit=False):
             query = (
                 query
                 .join(permissions).on(permissions.id == passwd_auth_perms.permission_id)
-                .where(permissions.name.notin(*(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
+                .where(permissions.name.notin(tuple(Parameter('%s') for _ in DEFAULT_PERMISSIONS)))
             )
 
         itgs.read_cursor.execute(

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -112,7 +112,7 @@ def grant_mod_permissions(itgs: 'LazyItgs', user_id: int, passwd_auth_id: int, c
     )
 
 
-def revoke_mod_permissions(itgs: LazyItgs, user_id: int, commit=False):
+def revoke_mod_permissions(itgs: 'LazyItgs', user_id: int, commit=False):
     """This function revokes all non-default permissions on the given user
     because they are no longer a moderator. This will apply to all
     authentication methods and will log them out. This will handle updating the

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -87,10 +87,11 @@ def grant_mod_permissions(itgs: 'LazyItgs', user_id: int, passwd_auth_id: int, c
                     Query.from_(passwd_auth_perms)
                     .where(passwd_auth_perms.password_authentication_id == Parameter('%s'))
                     .where(passwd_auth_perms.permission_id == permissions.id)
-                    .get_sql()
                 )
             )
         )
+        .get_sql(),
+        (passwd_auth_id,)
     )
     perm_ids_to_grant = []
     row = itgs.read_cursor.fetchone()

--- a/src/utils/mod_onboarding_utils.py
+++ b/src/utils/mod_onboarding_utils.py
@@ -16,7 +16,7 @@ DEFAULT_PERMISSIONS = tuple(os.getenv('DEFAULT_PERMISSIONS', '').split(','))
 """The list of permissions we grant to new users when they sign up"""
 
 
-def store_letter_message(itgs: LazyItgs, user_id: int, letter_name: str, commit=False):
+def store_letter_message(itgs: 'LazyItgs', user_id: int, letter_name: str, commit=False):
     """This function is responsible for storing that we sent an onboarding
     letter message to the given user, where the subject and body were
     fetched as if by `lbshared.responses.get_letter_response`
@@ -64,7 +64,7 @@ def store_letter_message(itgs: LazyItgs, user_id: int, letter_name: str, commit=
         itgs.write_conn.commit()
 
 
-def grant_mod_permissions(itgs: LazyItgs, user_id: int, passwd_auth_id: int, commit=False):
+def grant_mod_permissions(itgs: 'LazyItgs', user_id: int, passwd_auth_id: int, commit=False):
     """This function grants the given user all the permissions that moderators
     should have on the given password authentication id. This will handle
     updating the audit tables.

--- a/src/utils/money_utils.py
+++ b/src/utils/money_utils.py
@@ -1,0 +1,74 @@
+"""This utility has convenience functions for working with money objects"""
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+from lbshared.money import Money
+import query_helper
+
+
+def find_or_create_money(itgs: LazyItgs, money: Money, amount_usd_cents: int) -> int:
+    """Find or create a row in the moneys table that matches the given money
+    object.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to use to connect to networked
+      services.
+    - `money (Money)`: The money object to create a corresponding row for.
+    - `amount_usd_cents (int)`: The money amount in USD cents at the current
+      conversion rate.
+    """
+    currencies = Table('currencies')
+    moneys = Table('moneys')
+
+    (currency_id,) = query_helper.find_or_create_or_find(
+        itgs,
+        (
+            Query.from_(currencies)
+            .select(currencies.id)
+            .where(currencies.code == Parameter('%s'))
+            .get_sql(),
+            (money.currency,)
+        ),
+        (
+            Query.into(currencies)
+            .columns(
+                currencies.code,
+                currencies.symbol,
+                currencies.symbol_on_left,
+                currencies.exponent
+            )
+            .insert(*(Parameter('%s') for _ in range(4)))
+            .returning(currencies.id)
+            .get_sql(),
+            (
+                money.currency,
+                money.symbol or f' {money.currency}',
+                money.symbol_on_left if money.symbol is not None else False,
+                money.exp or 2
+            )
+        )
+    )
+    (money_id,) = query_helper.find_or_create_or_find(
+        itgs,
+        (
+            Query.from_(moneys)
+            .select(moneys.id)
+            .where(moneys.currency_id == Parameter('%s'))
+            .where(moneys.amount == Parameter('%s'))
+            .where(moneys.amount_usd_cents == Parameter('%s'))
+            .get_sql(),
+            (currency_id, money.minor, amount_usd_cents)
+        ),
+        (
+            Query.into(moneys)
+            .columns(
+                moneys.currency_id,
+                moneys.amount,
+                moneys.amount_usd_cents
+            )
+            .insert(*(Parameter('%s') for _ in range(3)))
+            .returning(moneys.id)
+            .get_sql(),
+            (currency_id, money.minor, amount_usd_cents)
+        )
+    )
+    return money_id

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -62,7 +62,7 @@ def grant_permissions(
             passwd_auth_events.user_id,
             passwd_auth_events.permission_id
         )
-        .insert(*(tuple(Parameter('%s') for _ in range(5))))
+        .insert(*(tuple(Parameter('%s') for _ in range(5)) for _ in range(perm_ids_to_grant)))
         .get_sql(),
         args
     )

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -25,6 +25,12 @@ def grant_permissions(
       to.
     """
     passwd_auth_perms = Table('password_auth_permissions')
+
+    args = []
+    for perm_id in perm_ids_to_grant:
+        args.append(passwd_auth_id)
+        args.append(perm_id)
+
     itgs.write_cursor.execute(
         Query.into(passwd_auth_perms)
         .columns(
@@ -35,10 +41,7 @@ def grant_permissions(
             *((Parameter('%s'), Parameter('%s')) for _ in perm_ids_to_grant)
         )
         .get_sql(),
-        tuple(
-            (passwd_auth_id, perm_id)
-            for perm_id in perm_ids_to_grant
-        )
+        args
     )
     passwd_auth_events = Table('password_authentication_events')
     itgs.write_cursor.execute(

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -98,7 +98,11 @@ def revoke_permissions(
     itgs.write_cursor.execute(
         Query.from_(passwd_auth_perms).delete()
         .where(passwd_auth_perms.password_authentication_id == Parameter('%s'))
-        .where(passwd_auth_perms.permission_id.isin(*(Parameter('%s') for _ in perm_ids_to_revoke)))
+        .where(
+            passwd_auth_perms.permission_id.isin(
+                tuple(Parameter('%s') for _ in perm_ids_to_revoke)
+            )
+        )
         .get_sql(),
         (passwd_auth_id, *perm_ids_to_revoke)
     )

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -62,7 +62,12 @@ def grant_permissions(
             passwd_auth_events.user_id,
             passwd_auth_events.permission_id
         )
-        .insert(*(tuple(Parameter('%s') for _ in range(5)) for _ in range(perm_ids_to_grant)))
+        .insert(
+            *(
+                tuple(Parameter('%s') for _ in range(5))
+                for _ in perm_ids_to_grant
+            )
+        )
         .get_sql(),
         args
     )

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -1,0 +1,115 @@
+"""Utility functions for granting and revoking permissions"""
+from pypika import PostgreSQLQuery as Query, Table, Parameter
+import typing
+
+if typing.TYPE_CHECKING:
+    from lbshared.lazy_integrations import LazyIntegrations as LazyItgs
+
+
+def grant_permissions(
+        itgs: LazyItgs, user_id: int, reason: str, passwd_auth_id: int,
+        perm_ids_to_grant: list, commit=False):
+    """Grants all of the given permissions to the given user. The permissions
+    to grant must not already be on the user. You must provide the password
+    authentication id to grant the permissions to. This will record the event
+    in the audit table.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to connect to networked services on
+    - `user_id (int)`: The user the password authentication id belongs to
+    - `passwd_auth_id (int)`: The password authentication to grant the
+      permissions to.
+    - `perm_ids_to_grant (list[int])`: The ids of the permissions to grant.
+      Must not be empty.
+    - `commit (bool)`: True to commit the transaction immediately, false not
+      to.
+    """
+    passwd_auth_perms = Table('password_auth_permissions')
+    itgs.write_cursor.execute(
+        Query.into(passwd_auth_perms)
+        .columns(
+            passwd_auth_perms.password_authentication_id,
+            passwd_auth_perms.permission_id
+        )
+        .insert(
+            *((Parameter('%s'), Parameter('%s')) for _ in perm_ids_to_grant)
+        )
+        .get_sql(),
+        tuple(
+            (passwd_auth_id, perm_id)
+            for perm_id in perm_ids_to_grant
+        )
+    )
+    passwd_auth_events = Table('password_authentication_events')
+    itgs.write_cursor.execute(
+        Query.into(passwd_auth_events)
+        .columns(
+            passwd_auth_events.password_authentication_id,
+            passwd_auth_events.type,
+            passwd_auth_events.reason,
+            passwd_auth_events.user_id,
+            passwd_auth_events.permission_id
+        )
+        .insert(
+            *(
+                (passwd_auth_id, 'permission-granted', reason, user_id, perm_id)
+                for perm_id in perm_ids_to_grant
+            )
+        )
+    )
+    if commit:
+        itgs.write_conn.commit()
+
+
+def revoke_permissions(
+        itgs: LazyItgs, user_id: int, reason: str, passwd_auth_id: int,
+        perm_ids_to_revoke: list, commit=False):
+    """Revokes all the given permissions from the given password authentication
+    id. The password authentication must have all of the permissions. This will
+    record the event in the audit table. This will log the user out.
+
+    Arguments:
+    - `itgs (LazyItgs)`: The integrations to connect to third part services on
+    - `user_id (int)`: The user the password authentication belong sto.
+    - `reason (str)`: The reason for revoking permissions
+    - `passwd_auth_id (int)`: The password authentication to revoke permissions
+      on.
+    - `perm_ids_to_revoke (list[int])`: The ids of the permissions to revoke
+    - `commit (bool)`: True to commit the transaction immediately, false not
+      to.
+    """
+    passwd_auth_perms = Table('password_auth_permissions')
+    itgs.write_cursor.execute(
+        Query.from_(passwd_auth_perms).delete()
+        .where(passwd_auth_perms.password_authentication_id == Parameter('%s'))
+        .where(passwd_auth_perms.permission_id.isin(*(Parameter('%s') for _ in perm_ids_to_revoke)))
+        .get_sql(),
+        (passwd_auth_id, *perm_ids_to_revoke)
+    )
+    passwd_auth_events = Table('password_authentication_events')
+    itgs.write_cursor.execute(
+        Query.into(passwd_auth_events)
+        .columns(
+            passwd_auth_events.password_authentication_id,
+            passwd_auth_events.type,
+            passwd_auth_events.reason,
+            passwd_auth_events.user_id,
+            passwd_auth_events.permission_id
+        )
+        .insert(
+            *(
+                (passwd_auth_id, 'permission-revoked', reason, user_id, perm_id)
+                for perm_id in perm_ids_to_revoke
+            )
+        )
+    )
+    authtokens = Table('authtokens')
+    itgs.write_cursor.execute(
+        Query.from_(authtokens)
+        .delete()
+        .where(authtokens.user_id == Parameter('%s'))
+        .get_sql(),
+        (user_id,)
+    )
+    if commit:
+        itgs.write_conn.commit()

--- a/src/utils/perm_utils.py
+++ b/src/utils/perm_utils.py
@@ -7,7 +7,7 @@ if typing.TYPE_CHECKING:
 
 
 def grant_permissions(
-        itgs: LazyItgs, user_id: int, reason: str, passwd_auth_id: int,
+        itgs: 'LazyItgs', user_id: int, reason: str, passwd_auth_id: int,
         perm_ids_to_grant: list, commit=False):
     """Grants all of the given permissions to the given user. The permissions
     to grant must not already be on the user. You must provide the password
@@ -62,7 +62,7 @@ def grant_permissions(
 
 
 def revoke_permissions(
-        itgs: LazyItgs, user_id: int, reason: str, passwd_auth_id: int,
+        itgs: 'LazyItgs', user_id: int, reason: str, passwd_auth_id: int,
         perm_ids_to_revoke: list, commit=False):
     """Revokes all the given permissions from the given password authentication
     id. The password authentication must have all of the permissions. This will


### PR DESCRIPTION
The core of the engine is complete so time to add some serious value-adds

- Lenders automatically enqueued into trust queue
- ModLog events now diverted to go through RabbitMQ
- Update default permissions to correctly go through the audit tables
- Automatically grant moderators all permissions at the later of when they gain moderator and when they claim their account
- Automatically revoke moderator permissions when they lose moderator status
- Automatically send moderators a list of messages specified in the database once per day until caught up (for onboarding)