### PR TITLE
Improve query helper find_or_create_or_find

### DIFF
--- a/src/query_helper.py
+++ b/src/query_helper.py
@@ -2,7 +2,7 @@
 import psycopg2
 
 
-def find_or_create_or_find(itgs, find_query, insert_query):
+def find_or_create_or_find(itgs, find_query, insert_query, commit=False):
     """This will execute the find query, returning the result row if there is
     one. Otherwise it will execute the insert query and return the result of
     that if there is no conflict. Finally, if the insert query causes a unique
@@ -15,7 +15,7 @@ def find_or_create_or_find(itgs, find_query, insert_query):
     unnecessarily. On the other hand a raw find or create is not thread-safe
     and if it were everywhere then the application is very fragile.
 
-    This will not commit.
+    This will not commit unless commit is set to True
 
     Arguments:
         itgs (LazyIntegrations): The lazy integrations to use. This will use
@@ -27,9 +27,13 @@ def find_or_create_or_find(itgs, find_query, insert_query):
             should return the inserted id. May raise a unique constraint failure.
             A tuple of two arguments, where the first argument is the SQL and the
             second is the parameters if any.
+        commit (bool): Default to false. If false, then this will raise an error
+            when the insert fails because the transaction aborted due to the error.
+            If true then this should be called while there is nothing on the write
+            connections transaction, and will return committed.
 
     Returns:
-        (tuple, None): The result from fetchone() after either a succesful find
+        (tuple, None): The result from fetchone() after either a successful find
             or a successful insert
     """
     itgs.write_cursor.execute(*find_query)
@@ -38,13 +42,21 @@ def find_or_create_or_find(itgs, find_query, insert_query):
         return res
     try:
         itgs.write_cursor.execute(*insert_query)
-        return itgs.write_cursor.fetchone()
+        res = itgs.write_cursor.fetchone()
+        if commit:
+            itgs.write_conn.commit()
+        return res
     except psycopg2.IntegrityError as ex:
         if ex.pgcode != '23505':
-            raise
+            raise Exception(f'non-integrity find_query={find_query}, insert_query={insert_query}')
+        if not commit:
+            raise Exception(f'integrity find_query={find_query}, insert_query={insert_query}')
+        itgs.write_conn.rollback()
 
     itgs.write_cursor.execute(*find_query)
     res = itgs.write_cursor.fetchone()
     if res is None:
-        raise Exception('find->create->find failed all 3')
+        raise Exception(f'find->create->find failed all 3; find_query={find_query}, insert_query={insert_query}')
+
+    itgs.write_conn.commit()
     return res


### PR DESCRIPTION
This improves the error message. Right now it's behavior is the same as before, but it
adds the optional parameter "commit" which can be set to true so that it doesn't require
autocommit. This didn't turn out to be the actual reason for the problem observed, which
was an integrity error on the id column because the sequence counter for users hadn't been
set to the old value since the last migration and we eventually filled the gap in user ids, causing
an error when creating new users. These error messages were super helpful in figuring that out